### PR TITLE
Payment fee totals tax calculations fix.

### DIFF
--- a/Model/Total/Quote/BuckarooFee.php
+++ b/Model/Total/Quote/BuckarooFee.php
@@ -129,7 +129,7 @@ class BuckarooFee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
             return $this;
         }
 
-        $basePaymentFee = $this->getBaseFee($methodInstance, $quote);
+        $basePaymentFee = $total->getBaseBuckarooFeeInclTax() - $total->getBuckarooFeeBaseTaxAmount();
 
         if ($basePaymentFee < 0.01) {
             return $this;
@@ -202,7 +202,8 @@ class BuckarooFee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
      */
     public function getBaseFee(
         \TIG\Buckaroo\Model\Method\AbstractMethod $methodInstance,
-        \Magento\Quote\Model\Quote $quote
+        \Magento\Quote\Model\Quote $quote,
+        $inclTax = false
     ) {
         $buckarooPaymentMethodCode = $methodInstance->buckarooPaymentMethodCode;
         if (!$this->configProviderMethodFactory->has($buckarooPaymentMethodCode)) {
@@ -213,6 +214,9 @@ class BuckarooFee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
         $basePaymentFee = trim($configProvider->getPaymentFee());
 
         if (is_numeric($basePaymentFee)) {
+            if($inclTax) {
+                return $basePaymentFee;
+            }
             /**
              * Payment fee is a number
              */

--- a/Model/Total/Quote/BuckarooFee.php
+++ b/Model/Total/Quote/BuckarooFee.php
@@ -196,6 +196,7 @@ class BuckarooFee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
     /**
      * @param \TIG\Buckaroo\Model\Method\AbstractMethod $methodInstance
      * @param \Magento\Quote\Model\Quote                $quote
+     * @param bool                                      $inclTax
      *
      * @return bool|false|float
      * @throws \TIG\Buckaroo\Exception
@@ -214,7 +215,7 @@ class BuckarooFee extends \Magento\Quote\Model\Quote\Address\Total\AbstractTotal
         $basePaymentFee = trim($configProvider->getPaymentFee());
 
         if (is_numeric($basePaymentFee)) {
-            if($inclTax) {
+            if ($inclTax) {
                 return $basePaymentFee;
             }
             /**

--- a/Model/Total/Quote/Tax/BuckarooFee.php
+++ b/Model/Total/Quote/Tax/BuckarooFee.php
@@ -103,7 +103,7 @@ class BuckarooFee extends \TIG\Buckaroo\Model\Total\Quote\BuckarooFee
             return $this;
         }
 
-        $basePaymentFee = $this->getBaseFee($methodInstance, $quote);
+        $basePaymentFee = $this->getBaseFee($methodInstance, $quote, true);
 
         if ($basePaymentFee < 0.01) {
             return $this;
@@ -129,7 +129,7 @@ class BuckarooFee extends \TIG\Buckaroo\Model\Total\Quote\BuckarooFee
             CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_BASE_UNIT_PRICE => $basePaymentFee,
             CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_QUANTITY => 1,
             CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_TAX_CLASS_ID => $productTaxClassId,
-            CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_PRICE_INCLUDES_TAX => false,
+            CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_PRICE_INCLUDES_TAX => true,
             CommonTaxCollector::KEY_ASSOCIATED_TAXABLE_ASSOCIATION_ITEM_CODE
             => CommonTaxCollector::ASSOCIATION_ITEM_CODE_FOR_QUOTE,
         ];


### PR DESCRIPTION
- Send the fee including tax to the CommonTaxCollector and changed the flag "TAXABLE_PRICE_INCLUDES_TAX" to true.
- Calculated the basePaymentFee in Quote/BuckarooFee.php based on existing parameters instead of refetching it.
- Added a incl_tax flag to the function getBaseFee to return the original tax included price of the fee (the one from the database).