### PR TITLE
Deleted interface reference

### DIFF
--- a/Model/ConfigProvider/AbstractConfigProvider.php
+++ b/Model/ConfigProvider/AbstractConfigProvider.php
@@ -38,9 +38,7 @@
  */
 namespace TIG\Buckaroo\Model\ConfigProvider;
 
-use \Magento\Checkout\Model\ConfigProviderInterface;
-
-abstract class AbstractConfigProvider implements ConfigProviderInterface
+abstract class AbstractConfigProvider
 {
     /**
      * @var string


### PR DESCRIPTION
This caused an issue because the interface doesn't have the $store paramater for getConfig() method
